### PR TITLE
Fix sort

### DIFF
--- a/site.js
+++ b/site.js
@@ -335,7 +335,7 @@ async function archive(username, options)
 				return 0;
 			}
 
-			return a.created_at > b.created_at ? 1 : -1;
+			return a.created_at > b.created_at ? -1 : 1;
 		});
 
 		for (var k in posts_html) {


### PR DESCRIPTION
if it returns a value < 0, 'a' will have a smaller index compared to 'b'

According to this doc for sort https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Array/sort, we want a.created_at > b.created_at to return a negative value so index of 'a' is smaller than index of 'b'